### PR TITLE
HLSLCrossCompiler: Fix NULL pointer dereference on dcl_uav_structured

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -745,20 +745,21 @@ const uint32_t* DecodeDeclaration(Shader* psShader, const uint32_t* pui32Token, 
 			psDecl->sUAV.ui32BufferSize = 0;
             DecodeOperand(pui32Token+ui32OperandOffset, &psDecl->asOperands[0]);
 			
-            GetResourceFromBindingPoint(RGROUP_UAV, psDecl->asOperands[0].ui32RegisterNumber, &psShader->sInfo, &psBinding);
-
-            GetConstantBufferFromBindingPoint(RGROUP_UAV, psBinding->ui32BindPoint, &psShader->sInfo, &psBuffer);
-            psDecl->sUAV.ui32BufferSize = psBuffer->ui32TotalSizeInBytes;
-			switch(psBinding->eType)
-			{
-			case RTYPE_UAV_RWSTRUCTURED_WITH_COUNTER:
-			case RTYPE_UAV_APPEND_STRUCTURED:
-			case RTYPE_UAV_CONSUME_STRUCTURED:
-				psDecl->sUAV.bCounter = 1;
-				break;
-			default:
-				break;
-			}
+            if (GetResourceFromBindingPoint(RGROUP_UAV, psDecl->asOperands[0].ui32RegisterNumber, &psShader->sInfo, &psBinding))
+            {
+                    GetConstantBufferFromBindingPoint(RGROUP_UAV, psBinding->ui32BindPoint, &psShader->sInfo, &psBuffer);
+                    psDecl->sUAV.ui32BufferSize = psBuffer->ui32TotalSizeInBytes;
+                    switch(psBinding->eType)
+                    {
+                    case RTYPE_UAV_RWSTRUCTURED_WITH_COUNTER:
+                    case RTYPE_UAV_APPEND_STRUCTURED:
+                    case RTYPE_UAV_CONSUME_STRUCTURED:
+                        psDecl->sUAV.bCounter = 1;
+                        break;
+                    default:
+                        break;
+                    }
+            }
             break;
         }
         case OPCODE_DCL_RESOURCE_STRUCTURED:


### PR DESCRIPTION
The following commit introduced a NULL pointer dereference that can
crash the HLSL cross compiler if it processes a shader that includes an
RWStructuredBuffer that has had its reflection information stripped:

    commit 0659b1f3dfe3c2617c0b6d5b96d54017dcf9cae9
    Author: James Jones <james.jones.jmj@gmail.com>
    Date:   Fri Jan 17 12:21:23 2014 +0000

        Fixes image_load_store and shader_storage_buffer_object features

This restores the if block to make the processing conditional on the
reflection information being found. This by itself may not be
immediately useful for the standalone HLSLCrossCompiler project that
does not expect to process stripped shaders, but it is necessary for
projects that use HLSLCrossCompiler as a library to decode shaders, such
as in 3DMigoto.